### PR TITLE
Add expo dev client support

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,6 +9,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { NavigationContainer } from "@react-navigation/native";
 import { LogBox } from "react-native";
 import initSentry from "./clients/sentry";
+import 'expo-dev-client';
 
 // This and the following two lines account for missing base64 support in some versions of Node
 import { decode, encode } from "base-64";

--- a/App.js
+++ b/App.js
@@ -9,7 +9,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { NavigationContainer } from "@react-navigation/native";
 import { LogBox } from "react-native";
 import initSentry from "./clients/sentry";
-import 'expo-dev-client';
+import 'expo-dev-client'; // Loads expo dev client tools
 
 // This and the following two lines account for missing base64 support in some versions of Node
 import { decode, encode } from "base-64";

--- a/clients/sentry.js
+++ b/clients/sentry.js
@@ -5,7 +5,9 @@ const initSentry = () => {
     let enableSentryLocally = false;
     let traceSampleRate = 0.5;
     if (__DEV__) {
-        enableSentryLocally = true;
+        // Set `enableSentryLocally` to true to enable Sentry while developing locally
+        // Preferably do not commit this change so we keep Sentry usage to deployed apps
+        enableSentryLocally = false; 
         traceSampleRate = 1.0;
     }
     Sentry.init({

--- a/eas.json
+++ b/eas.json
@@ -3,6 +3,15 @@
     "base": {
       "env": {}
     },
+    "devLocal": {
+      "extends": "base",
+      "distribution": "internal",
+      "channel": "dev",
+      "developmentClient": true,
+      "env": {
+        "GREENUP_ENVIRONMENT": "dev"
+      }
+    },
     "dev": {
       "extends": "base",
       "distribution": "internal",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "expo-camera": "~13.4.4",
     "expo-constants": "~14.4.2",
     "expo-contacts": "~12.2.0",
+    "expo-dev-client": "~2.4.13",
     "expo-device": "~5.4.0",
     "expo-file-system": "~15.4.5",
     "expo-font": "~11.4.0",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "main": "node_modules/expo/AppEntry.js",
   "name": "green-up-vermont-mobile-app",
   "scripts": {
-    "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "start": "expo start --go",
+    "android": "expo start --go --android",
+    "ios": "expo start --go --ios",
     "test": "jest --watchAll --coverage",
     "test-ci": "jest",
     "lint": "eslint ./",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3872,6 +3872,47 @@ expo-contacts@~12.2.0:
   dependencies:
     uuid "^3.4.0"
 
+expo-dev-client@~2.4.13:
+  version "2.4.13"
+  resolved "https://registry.yarnpkg.com/expo-dev-client/-/expo-dev-client-2.4.13.tgz#cf8c829e2f815b273db44c17e513d5410af5b7fa"
+  integrity sha512-EBNJlPntw+DZy7mKxYvpdrmE2GU4YjcEpxSLpwNn2GDwy7e2xXAC2k/25E13BGy3yKPLo1iBXNgB01uleIDdVg==
+  dependencies:
+    expo-dev-launcher "2.4.15"
+    expo-dev-menu "3.2.4"
+    expo-dev-menu-interface "1.3.0"
+    expo-manifests "~0.7.0"
+    expo-updates-interface "~0.10.0"
+
+expo-dev-launcher@2.4.15:
+  version "2.4.15"
+  resolved "https://registry.yarnpkg.com/expo-dev-launcher/-/expo-dev-launcher-2.4.15.tgz#298ac56b523f77c40523453224f75dcc894198bc"
+  integrity sha512-6oF4NsxlKwuafnyIZvVtMp4OTxRu4Arsw6qJ9s4jDjZuGJtGwgEj9ux3R0YLkDPs8xhsK9Awp0q17RqbQzs1qg==
+  dependencies:
+    expo-dev-menu "3.2.3"
+    resolve-from "^5.0.0"
+    semver "^7.5.3"
+
+expo-dev-menu-interface@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/expo-dev-menu-interface/-/expo-dev-menu-interface-1.3.0.tgz#51b6be8c6e0ce73e414ac7a545998dfad0dfdb80"
+  integrity sha512-WtRP7trQ2lizJJTTFXUSGGn1deIeHaYej0sUynvu/uC69VrSP4EeSnYOxbmEO29kuT/MsQBMGu0P/AkMQOqCOg==
+
+expo-dev-menu@3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/expo-dev-menu/-/expo-dev-menu-3.2.3.tgz#31c102251d94e9a35fac667cefdbaeae7b1e1375"
+  integrity sha512-DneF3okTC4AAfAZgaOIylQ/UngSO8SnUT6bRV6nHhJU/jQS1OIP1cZoNW23I100+2yj6x6mobL21PxyiI5VA8g==
+  dependencies:
+    expo-dev-menu-interface "1.3.0"
+    semver "^7.5.3"
+
+expo-dev-menu@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/expo-dev-menu/-/expo-dev-menu-3.2.4.tgz#25ba1efe70bf74ab2d7804eab54212785cd2a01a"
+  integrity sha512-jPvEY4xGTsiVL6A8M6xThNG+tgCHKlDaWqmWHT+wy2EXgFf/7zE0daVYoFms0KJ1XtZc+/DmDRgIPTR86qIGTg==
+  dependencies:
+    expo-dev-menu-interface "1.3.0"
+    semver "^7.5.3"
+
 expo-device@~5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/expo-device/-/expo-device-5.4.0.tgz#4dc4db4b2265d1f5c9d7c2be6548c375882be437"


### PR DESCRIPTION
Adds expo dev client support for a specific build profile.

This enables a much better developer experience for tracking down bugs with better tooling.